### PR TITLE
added docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,36 @@
+FROM rust:bullseye AS build
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN curl -fsSL https://deb.nodesource.com/setup_17.x | bash - \
+    && apt-get update \
+    && apt-get install -y nodejs openjdk-17-jdk \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm install -g yarn \
+    && cargo install just
+
+RUN git clone https://github.com/Eugeny/warpgate /opt/warpgate \
+    && cd /opt/warpgate \
+    && just yarn \
+    && just yarn build \
+    && cargo build
+
+FROM debian:bullseye
+LABEL maintainer=heywoodlh
+
+COPY --from=build /opt/warpgate/target/debug/warpgate /usr/local/bin/warpgate
+COPY run.sh /run.sh
+COPY expect.sh /expect.sh
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update \
+    && apt-get install -y expect openssl \
+    && rm -rf /var/lib/apt/lists/*
+
+EXPOSE 2222
+EXPOSE 8888
+
+VOLUME /data
+
+ENTRYPOINT ["/run.sh"]

--- a/docker/expect.sh
+++ b/docker/expect.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/expect -f
+
+set password [lindex $argv 0];
+
+spawn warpgate hash
+expect "*Password to be hashed*"
+send -- "$password\r"
+expect eof

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+[[ -n ${ADMIN_USER} ]] || ADMIN_USER='admin'
+[[ -n ${ADMIN_PASS} ]] || ADMIN_PASS='admin'
+
+[[ -e /data/web-admin.certificate.pem ]] || openssl req -x509 -nodes -days 7300 -newkey rsa:4096 -keyout /data/web-admin.key.pem -out /data/web-admin.certificate.pem -subj "/C=PE/ST=Lima/L=Lima/O=Acme Inc. /OU=IT Department/CN=acme.com"
+
+password_hash=$(/expect.sh "${ADMIN_PASS}" | tail -1 | sed 's/\r$//')
+
+cat << EOF > /etc/warpgate.yaml
+---
+targets:
+  - name: web-admin
+    allow_roles:
+      - "warpgate:admin"
+    web_admin: {}
+users:
+  - username: ${ADMIN_USER}
+    credentials:
+      - type: password
+        hash: "${password_hash}"
+    roles:
+      - "warpgate:admin"
+roles:
+  - name: "warpgate:admin"
+recordings:
+  enable: true
+  path: /data/recordings
+web_admin:
+  enable: true
+  listen: "0.0.0.0:8888"
+  certificate: /data/web-admin.certificate.pem
+  key: /data/web-admin.key.pem
+database_url: "sqlite:/data/db"
+ssh:
+  listen: "0.0.0.0:2222"
+  keys: /data/ssh-keys
+  client_key: "./client_key"
+retention: 7days
+EOF
+
+warpgate -c /etc/warpgate.yaml $@


### PR DESCRIPTION
I would love to have something like warpgate running in my K8s cluster which is why I packaged it as a Docker image. 

Right now, it's a bit hackey to use `expect` to write the password to a variable but if you implement https://github.com/Eugeny/warpgate/issues/15 I think the `expect` stuff would not be necessary.

In regard to current usage something like this would be sufficient:

```
docker run -it -e ADMIN_USER='heywoodlh' -e ADMIN_PASS='heywoodlh' -p 8888:8888 -p 2222:2222 --rm warpgate run
```